### PR TITLE
mozcモードの複数セグメント変換時のカーソル位置バグを修正

### DIFF
--- a/lisp/sumibi.el
+++ b/lisp/sumibi.el
@@ -1532,19 +1532,20 @@ Argument E: リージョンの終了位置
 Argument SEGMENTS: セグメントのリスト
 Argument INVERSE-FLAG：逆変換かどうか"
   (let ((current-pos b)
-        (original-text (buffer-substring-no-properties b e)))
-    (save-excursion
-      (goto-char b)
-      (delete-region b e)
-      (dolist (segment segments)
-        (when (> (length segment) 0)
-          (let ((segment-start (point))
-                (segment-end (+ (point) (length segment))))
-            (insert segment)
-            ;; 個別セグメントを変換
-            (sumibi-henkan-region-sync segment-start segment-end inverse-flag)
-            ;; セグメント間にスペースを挿入しない（元の仕様通り）
-            ))))))
+        (original-text (buffer-substring-no-properties b e))
+        (final-pos nil))
+    (goto-char b)
+    (delete-region b e)
+    (dolist (segment segments)
+      (when (> (length segment) 0)
+        (let ((segment-start (point))
+              (segment-end (+ (point) (length segment))))
+          (insert segment)
+          ;; 個別セグメントを変換
+          (sumibi-henkan-region-sync segment-start segment-end inverse-flag)
+          (setq final-pos (point)))))
+    ;; 最終位置にカーソルを設定（save-excursionを使わないため手動制御）
+    (when final-pos (goto-char final-pos))))
 
 
 (defun sumibi-char-charset (ch)


### PR DESCRIPTION
  - sumibi-henkan-region-mozc-multiple-segments から save-excursion を削除
  - 複数文節変換後にカーソルが文頭に戻る問題を修正
  - 変換後のカーソル位置を文末に正しく保持するように改善
  - 重複するundo制御を回避してundoバッファエラーを解決

  Fixes #88

  詳細説明:
  - issue #88で報告されたmozcモードでの複数文節変換時のカーソル位置問題を修正
  - save-excursionによるカーソル位置の自動復元を停止
  - 変換後の連続入力が可能になるようにカーソル位置を改善