### PR TITLE
ローカルLLMの選択肢に gemma-4-12b-it-mlx を追加 (Issue #160)

### DIFF
--- a/lisp/sumibi.el
+++ b/lisp/sumibi.el
@@ -104,7 +104,7 @@
     (local
      :base-url "http://127.0.0.1:1234/v1"
      :model "google/gemma-4-e4b"
-     :model-list ("google/gemma-4-e4b" "google/gemma-4-26b-a4b" "mlx-community/gemma-4-26b-a4b-it")
+     :model-list ("google/gemma-4-e4b" "google/gemma-4-26b-a4b" "mlx-community/gemma-4-26b-a4b-it" "gemma-4-12b-it-mlx")
      :api-key-env ()))
   "各プロバイダーのデフォルト設定。")
 


### PR DESCRIPTION
## 概要

Issue #160 対応。ローカルLLMプロバイダー (`sumibi-provider` = 'local) の選択可能モデル一覧に `gemma-4-12b-it-mlx` を追加しました。

## 変更点
`lisp/sumibi.el` の `sumibi-provider-defaults` 内 `local` の `:model-list` に1モデル追加:

```elisp
:model-list ("google/gemma-4-e4b" "google/gemma-4-26b-a4b" "mlx-community/gemma-4-26b-a4b-it" "gemma-4-12b-it-mlx")
```

## 根拠
ベンチマーク (#158 / PR #159) で、MLX版が非MLX版より速度・精度ともに改善することを確認済み:

| 指標 | gemma-4-12b (非MLX) | gemma-4-12b-it-mlx |
|---|---|---|
| hiragana CER | 22.0% | **17.1%** |
| hiragana 中央値応答時間 | 9.80秒 | **5.19秒** (約1.9倍高速) |

## 動作確認
- ✅ 括弧バランスチェック (`agent-lisp-paren-aid lisp/sumibi.el`): ok
- ✅ 全テスト合格 (`make test`): 82件すべて 0 unexpected

## 補足
`gemma-4-12b-it-mlx` はアーキテクチャ `gemma4_unified` のため、LM Studio の MLXランタイム **mlx-llm 1.9.0 (beta) 以降** が必要です。

Closes #160