### PR TITLE
gpt-5.6-terra/luna を採用しデフォルトモデルに変更 (Issue #167)

### DIFF
--- a/lisp/sumibi.el
+++ b/lisp/sumibi.el
@@ -89,7 +89,7 @@
   '((openai
      :base-url "https://api.openai.com/v1"
      :model "gpt-5.6-terra"
-     :model-list ("gpt-5.6-terra" "gpt-5.6-luna" "gpt-5.4" "gpt-5.2" "gpt-5.1" "gpt-5" "gpt-5-mini" "gpt-4.1" "gpt-4.1-mini" "gpt-4o" "gpt-4o-mini")
+     :model-list ("gpt-5.6-terra" "gpt-5.6-luna" "gpt-5.4" "gpt-5.2" "gpt-5.1")
      :api-key-env ("SUMIBI_AI_API_KEY" "OPENAI_API_KEY"))
     (gemini
      :base-url "https://generativelanguage.googleapis.com/v1beta/openai"

--- a/lisp/sumibi.el
+++ b/lisp/sumibi.el
@@ -88,8 +88,8 @@
 (defconst sumibi-provider-defaults
   '((openai
      :base-url "https://api.openai.com/v1"
-     :model "gpt-5.4"
-     :model-list ("gpt-5.4" "gpt-5.2" "gpt-5.1" "gpt-5" "gpt-5-mini" "gpt-4.1" "gpt-4.1-mini" "gpt-4o" "gpt-4o-mini")
+     :model "gpt-5.6-terra"
+     :model-list ("gpt-5.6-terra" "gpt-5.6-luna" "gpt-5.4" "gpt-5.2" "gpt-5.1" "gpt-5" "gpt-5-mini" "gpt-4.1" "gpt-4.1-mini" "gpt-4o" "gpt-4o-mini")
      :api-key-env ("SUMIBI_AI_API_KEY" "OPENAI_API_KEY"))
     (gemini
      :base-url "https://generativelanguage.googleapis.com/v1beta/openai"
@@ -801,11 +801,13 @@ loginは 'apikey' を想定."
          (string-match-p "\\`gpt-5" model))))
 
 (defun sumibi-gpt51-p ()
-  "現在のモデルがGPT-5.1/5.2/5.4かどうかを判定する.
-これらのモデルはreasoning_effort=noneを使用する."
+  "現在のモデルがGPT-5.1/5.2/5.4/5.6-terra/5.6-luna かどうかを判定する.
+これらのモデルはreasoning_effort=noneを使用する
+(gpt-5.6-terra/luna は `minimal' 非対応)."
   (let ((model (sumibi-ai-model)))
     (and (stringp model)
-         (string-match-p "\\`gpt-5\\.[124]\\'" model))))
+         (or (string-match-p "\\`gpt-5\\.[124]\\'" model)
+             (string-match-p "\\`gpt-5\\.6-" model)))))
 
 (defun sumibi-modeline-string ()
   "利用するモデル名を表示する."


### PR DESCRIPTION
## 概要

OpenAI の新モデル **gpt-5.6-terra / gpt-5.6-luna** を採用し、`sumibi-provider-defaults` のデフォルトモデルと `model-list` を更新しました。あわせて古いモデルを整理しています。(Issue #167)

## 変更内容

- OpenAI プロバイダのデフォルトモデルを `gpt-5.4` → **`gpt-5.6-terra`** に変更
- `model-list` を gpt-5.6-terra / gpt-5.6-luna / gpt-5.4 / gpt-5.2 / gpt-5.1 に整理
- `sumibi-gpt51-p`（`reasoning_effort=none` を使うモデル判定）に gpt-5.6-terra/luna を追加。これらは `minimal` 非対応のため none を使用

## モデル選択の指針

- **gpt-5.6-terra（推奨・デフォルト）**: 性能とレスポンスのバランスが一番よく取れており、通常はこれがおすすめです。
- **gpt-5.6-luna**: terra より少しだけ性能は落ちますが、費用を安く抑えたい場合はこちらを選択してください。

## 古いモデルの削除

GPT の古いモデル（`gpt-5` / `gpt-5-mini` / `gpt-4.1` / `gpt-4.1-mini` / `gpt-4o` / `gpt-4o-mini`）は、OpenAI API から deprecated（廃止予定）の通知が来ているため、`model-list` から外しました。

## 動作確認

- 括弧バランスチェック（`agent-lisp-paren-aid`）: OK

Closes #167
